### PR TITLE
Restcall fix for DELETE

### DIFF
--- a/src/PassSlot.php
+++ b/src/PassSlot.php
@@ -310,7 +310,7 @@ class PassSlot {
 				$httpHeaders[] = 'Content-Type: application/json';
 			}
 		} else if ($httpMethod == 'DELETE') {
-			curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $httpHeaders);
+			curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $httpMethod);
 		}
 
 		curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);


### PR DESCRIPTION
DELETE call is now properly sent.

Before the fix, httpHeaders was set as the request method... Result was a 502 error from Google.
